### PR TITLE
Add support for custom holidays providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ echo $datetime->format('Y-m-d H:i:s') . PHP_EOL;
 // 2016-01-08 12:43:28
 
 ```
+
+### Custom Holiday Providers
+```php
+class CustomHolidaysProvider implements Petaak\Workdays\HolidaysProvider\IHolidaysProvider
+{
+    // ...
+}
+
+// initialize workdays util without country code; the correct holidays provider is not yet available
+$workdaysUtil = new Petaak\Workdays\WorkdaysUtil();
+$workdaysUtil->registerHolidaysProvider(new CustomHolidaysProvider(), 'ZZ');
+// set the default country once the holidays provider is registered
+$workdaysUtil->setCountry('ZZ');
+
+```

--- a/src/Workdays/WorkdaysUtil.php
+++ b/src/Workdays/WorkdaysUtil.php
@@ -19,12 +19,35 @@ class WorkdaysUtil
     /** @var IHolidaysProvider */
     private $holidaysProvider;
 
+    /**
+     * @var IHolidaysProvider[]
+     */
+    private $holidayProviderRegistry = array();
+
     /** @const int Limit for the getNextHoliday function */
     const MAX_YEARS_WITH_NO_HOLIDAY = 100;
 
     public function __construct($countryCode = 'CZE')
     {
         $this->setCountry($countryCode);
+    }
+
+    /**
+     *
+     * @param string $countryCode
+     */
+    public function setCountry($countryCode = null)
+    {
+        $this->holidaysProvider = $this->getHolidaysProviderByCountryCode($countryCode);
+    }
+
+    /**
+     * @param IHolidaysProvider $holidayProvider
+     * @param string $countryCode
+     */
+    public function registerHolidaysProvider(IHolidaysProvider $holidayProvider, $countryCode)
+    {
+        $this->holidayProviderRegistry[$countryCode] = $holidayProvider;
     }
 
     /**
@@ -206,20 +229,14 @@ class WorkdaysUtil
     /**
      *
      * @param string $countryCode
-     */
-    private function setCountry($countryCode = null)
-    {
-        $this->holidaysProvider = $this->getHolidaysProviderByCountryCode($countryCode);
-    }
-
-    /**
-     *
-     * @param string $countryCode
      * @return IHolidaysProvider
      * @throws InvalidArgumentException
      */
     private function getHolidaysProviderByCountryCode($countryCode)
     {
+        if (array_key_exists($countryCode, $this->holidayProviderRegistry)) {
+            return $this->holidayProviderRegistry[$countryCode];
+        }
         $providerNamespace = '\\Petaak\\Workdays\\HolidaysProvider\\';
         $className = $providerNamespace . ucfirst(strtolower($countryCode));
         if (class_exists($className)) {

--- a/tests/Workdays/WorkdaysUtilTest.phpt
+++ b/tests/Workdays/WorkdaysUtilTest.phpt
@@ -10,6 +10,7 @@ use Tester\TestCase;
 require __DIR__ . '/../bootstrap.php';
 require __DIR__ . '/../src/PoorCountryWithNoHolidays.php';
 require __DIR__ . '/../src/PoorCountryWithFewHolidays.php';
+require __DIR__ . '/../src/CustomHolidaysProvider.php';
 
 /**
  * Description of WorkdaysUtilTest
@@ -285,6 +286,14 @@ class WorkdaysUtilTest extends TestCase
             }
         }
         return $data;
+    }
+
+    public function testCustomProvider()
+    {
+        $util = new WorkdaysUtil();
+        $util->registerHolidaysProvider(new \Acme\Demo\HolidaysProvider\CustomHolidaysProvider(), 'DE');
+        $util->setCountry('DE');
+        Assert::false($util->isWorkday(new DateTime('2019-10-03')));
     }
 }
 

--- a/tests/src/CustomHolidaysProvider.php
+++ b/tests/src/CustomHolidaysProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Acme\Demo\HolidaysProvider;
+
+use DateTime;
+use Petaak\Workdays\Holiday;
+use Petaak\Workdays\HolidaysProvider\BaseHolidaysProvider;
+use Petaak\Workdays\HolidaysProvider\IHolidaysProvider;
+
+/**
+ * Description of PoorCountryWithFewHolidays
+ */
+class CustomHolidaysProvider extends BaseHolidaysProvider implements IHolidaysProvider
+{
+
+    /**
+     * @param int $year
+     * @return Holiday[]
+     */
+    public function getHolidaysByYear($year)
+    {
+        $holidays = [];
+        $holidays[] = new Holiday(new DateTime($year . '-01-01'), 'Neujahr');
+        $holidays[] = new Holiday(new DateTime($year . '-10-03'), 'Tag der Deutschen Einheit');
+        $holidays[] = new Holiday(new DateTime($year . '-12-25'), 'Erster Weihnachtstag');
+        $holidays[] = new Holiday(new DateTime($year . '-12-26'), 'Zweiter Weihnachtstag');
+        return $holidays;
+    }
+}


### PR DESCRIPTION
This PR adds the possibility to register custom holiday providers in the utility like that:
```php
class CustomHolidaysProvider implements Petaak\Workdays\HolidaysProvider\IHolidaysProvider
{
    // ...
}

$workdaysUtil = new Petaak\Workdays\WorkdaysUtil();
$workdaysUtil->registerHolidaysProvider(new CustomHolidaysProvider(), 'ZZ');
```
Registering an instance over e.g. a class name comes with the benefit that this instance may be initialized with custom options already.
Unfortunately I can't initialize the utility with the new country code which we then register a provider for, so I exposed `WorkdaysUtil::setCountry`. Arguably it might be better to retrieve `WorkdaysUtil::holidaysProvider` only on first use (or try to fetch an implementation according to a property `WorkdaysUtil::countryCode` each use).