### PR TITLE
Compare php easter_date() with method getEasterSundayTester()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">= 5.4.0"
     },
     "require-dev": {
+        "ext-calendar": "*",
         "nette/tester": "^1.6"
     },
     "autoload": {

--- a/tests/Workdays/HolidaysProvider/BaseHolidaysProviderTest.phpt
+++ b/tests/Workdays/HolidaysProvider/BaseHolidaysProviderTest.phpt
@@ -50,6 +50,16 @@ class BaseHolidaysProviderTest extends TestCase
             [2028, '2028-04-16'],
         ];
     }
+
+    public function testPhpEasterDate()
+    {
+        $provider = new HolidayProvider();
+        for ($year = 1970; $year < 2037; ++$year) {
+            $result = $provider->getEasterSundayTester($year);
+
+            Assert::equal($result->format('Y-m-d'), date('Y-m-d', easter_date($year)));
+        }
+    }
 }
 
 $test = new BaseHolidaysProviderTest();

--- a/tests/config/php.ini
+++ b/tests/config/php.ini
@@ -1,0 +1,1 @@
+extension=calendar

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -3,4 +3,4 @@
 path_to_script_directory="$(dirname "$0")"
 cd "$path_to_script_directory";
 
-../vendor/bin/tester .
+../vendor/bin/tester . -c config/php.ini


### PR DESCRIPTION
Ahoj,
zkusil jsem porovnat implementovanou metodu pro získání velikonoční neděle s php funkcí easter_date() a dává to stejný výsledky.

Pokud by se ti to líbilo a změnu by jsi chtěl, upravil bych typo a dotáhnul PR.

---

Hello,
i try to compare implemented method for to get easter sunday with php native function easter_date() and results are same.

If you confirm this replace, i will update typo and i finish the PR.