### PR TITLE
Bump minimum PHP version to 5.6, run Travis CI for 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">= 5.4.0"
+        "php": ">= 5.6.0"
     },
     "require-dev": {
         "nette/tester": "^1.6"


### PR DESCRIPTION
Fixes #5

As this is a breaking change, the new release including this change should be `0.3.0`. As PHP 5.6 (and also 7.0 and 7.1) are unsupported, it might even make sense to bump the minimum version to 7.2 instead. This would also allow to use scalar type hints and return types. What do you think, @petaak?